### PR TITLE
Update contributions guidelines to reflect account data requests instead of delete

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,25 +3,24 @@
 The sites, urls and additional notes are stored in `_data/sites.json`. If you want to add a site to the list you'll need the following information:
 
 - `name`: The name of the service.
-- `url`: The url of the account-deletion page. If no such page exists, the url should be a contact or help page explaining the process of account deletion.
-- `url_CODE`: *(optional)* Use the language `CODE` as suffix of the url field to provide language-specific deletion codes, shown on the respective language page.
-- `difficulty`: This is an indicator used on the site to determine the difficulty of account deletion. Use one of:
-    - `easy`: Sites with a simple process such as a 'delete account' button
-    - `medium`: Sites that do allow account deletion but require you to perform additional steps
-    - `hard`: Sites that require you to contact customer services or those that don't allow automatic or easy account deletion
-    - `impossible`: For sites where it's basically impossible to totally delete your account, even if you contact them
-- `notes`: *(optional)* Notes will be shown when someone hovers on that service. Notes may include additional information you might need to delete your account (e.g. Skype) or consequences of deleting your account (e.g. iTunes).
-- `notes_CODE`: *(optional)* Use the language `CODE` as suffix of the `notes` field to provide language-specific instructions, shown on the respective language page.
-- `email`: *(optional)* If you have to send an email to a company to cancel your account, add the email address here. We'll do the rest.
-- `email_subject`: *(optional)* Set the subject for the email link. If unset, the default text is "Account Deletion Request".
-- `email_body`: *(optional)* Set the body for the email link. If unset, the default text is "Please delete my account, my username is XXXXXX".
-- `domains`: This is used by the [Chrome extension](https://github.com/jdm-contrib/justdelete.me-chrome-extension)
+- `url`: The url of the account data request page. If no such page exists, the url should be a contact or help page explaining the process for requesting account data.
+- `url_CODE`: _(optional)_ Use the language `CODE` as suffix of the url field to provide language-specific data request codes, shown on the respective language page.
+- `difficulty`: This is an indicator used on the site to determine the difficulty of requesting account data. Use one of:
+  - `easy`: Sites with a simple process such as a 'download account' button
+  - `medium`: Sites that do allow account data requests but require you to perform additional steps
+  - `hard`: Sites that require you to contact customer services or those that don't allow automatic or easy account data requests
+  - `impossible`: For sites where it's basically impossible to totally request your account data, even if you contact them
+- `notes`: Notes will be shown when someone hovers on that service. Notes may include additional information you might need to request your account data or consequences of requesting your account data.
+- `notes_CODE`: _(optional)_ Use the language `CODE` as suffix of the `notes` field to provide language-specific instructions, shown on the respective language page.
+- `email`: _(optional)_ If you have to send an email to a company to request your account data, add the email address here. We'll do the rest.
+- `email_subject`: _(optional)_ Set the subject for the email link. If unset, the default text is "Account Data Request".
+- `email_body`: _(optional)_ Set the body for the email link. If unset, the default text is "Please send me my account data. My username is XXXXXX".
 
 ## Contribution checklist
 
 1. Have you updated to the latest version of the project? `git pull`
 2. If you have modified an existing service's difficulty, please explain why/give sources.
-3. URLs must be direct links to either deletion, or if this is not available, a relevant help article.
+3. URLs must be direct links to either account data request, or if this is not available, a relevant help article.
 4. Any steps for the process should be detailed in the notes (if necessary).
 5. Be sure to indent 4 spaces per level.
 6. Be sure to place your entry ALPHABETICALLY in the current list.
@@ -34,7 +33,6 @@ If you want to help on the translation of the site, you can read [translation re
 ### Modify an existing Translation
 
 Look for the `CODE.json` file in the `_data/trans/` directory where `CODE` is your [short country code](https://en.wikipedia.org/wiki/Country_code)
-
 
 ### Add a new translation
 


### PR DESCRIPTION
- Updated to reflect that this repo is for account requests instead of deletions
- Removed the reference to `domains`
- Removed the optional flag for `notes` since it seems like there is an expectation that something is provided here per https://github.com/daviddavo/jgmd/pull/90#issuecomment-1269412848.