### PR TITLE
removed notes_cs-CZ and notes_es-ES from Gearbest (copy of notes)

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -169,9 +169,7 @@
         "name": "GearBest",
         "url": "https://www.gearbest.com/",
         "difficulty": "hard",
-        "notes": "You may send us an e-mail to support@gearbest.com to exercise your rights. We will respond to your request in a reasonable timeframe. We will take all reasonable steps to ensure that your personal data is correct and up to date.",
-        "notes_es-ES": "You may send us an e-mail to support@gearbest.com to exercise your rights. We will respond to your request in a reasonable timeframe. We will take all reasonable steps to ensure that your personal data is correct and up to date.",
-        "notes_cs-CZ": "You may send us an e-mail to support@gearbest.com to exercise your rights. We will respond to your request in a reasonable timeframe. We will take all reasonable steps to ensure that your personal data is correct and up to date."
+        "notes": "You may send us an e-mail to support@gearbest.com to exercise your rights. We will respond to your request in a reasonable timeframe. We will take all reasonable steps to ensure that your personal data is correct and up to date."
     },
 
     {


### PR DESCRIPTION
Removed `notes_cs-CZ` and `notes_es-ES`from `Gearbest`, becuase they were identical to `notes`.