### PR TITLE
Add Cloudflare as hard

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -99,6 +99,14 @@
     },
 
     {
+        "name": "Cloudflare",
+        "url": "https://www.cloudflare.com/privacypolicy/",
+        "difficulty": "hard",
+        "notes": "Cloudflare only accepts access requests via email.",
+        "email": "SAR@cloudflare.com"
+    },
+
+    {
         "name": "Coinbase",
         "url": "https://help.coinbase.com/en/pro/privacy-and-security/data-privacy/gdpr-how-to-access-information.html",
         "difficulty": "easy",


### PR DESCRIPTION
Despite having a relatively easy way to delete your account, they don't make the process for access requests that visible (it's down the page a bit - section 8).