### PR TITLE
Fix german translation

### DIFF
--- a/_data/trans/de-DE.json
+++ b/_data/trans/de-DE.json
@@ -19,7 +19,7 @@
     "hideinfo": "Informationen ausblenden...",
     "link_jdm": "Besuchen Sie JustDeleteMe",
     "link_jwtd": "Besuche JustWhatsTheData",
-    "name": "Englisch",
+    "name": "Deutsch",
     "noinfo": "Weitere Informationen nicht vorhanden",
     "noresults": "Finden Sie nicht, wonach Sie suchen?",
     "noresultshelp": "Hilf mit, JustGetMyData zu verbessern",


### PR DESCRIPTION
For some reason `name` was just `English` translated to german (`Englisch`), but it should have been the name of the language (`German` -> `Deutsch`) instead.