### PR TITLE
Update Yahoo with language specific urls

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -831,6 +831,10 @@
     {
         "name": "Yahoo!",
         "url": "https://yahoo.com/",
+        "url_de-DE": "https://de.yahoo.com/",
+        "url_en-GB": "https://uk.yahoo.com/",
+        "url_es-ES": "https://espanol.yahoo.com/",
+        "url_fr-FR": "https://fr.yahoo.com/",
         "difficulty": "easy",
         "notes": "Go to https://yahoo.mydashboard.oath.com/ with a Yahoo! account, scroll down and select 'Request a download' and on the next page you select all the data you want to download, then add an email that you want notify when the download will be ready, this process may take about 30 days."
     },

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -830,7 +830,7 @@
 
     {
         "name": "Yahoo!",
-        "url": "https://es.yahoo.com/",
+        "url": "https://yahoo.com/",
         "difficulty": "easy",
         "notes": "Go to https://yahoo.mydashboard.oath.com/ with a Yahoo! account, scroll down and select 'Request a download' and on the next page you select all the data you want to download, then add an email that you want notify when the download will be ready, this process may take about 30 days."
     },


### PR DESCRIPTION
For some reason, the default url for yahoo is the spanish version (`https://espanol.yahoo.com/`). I changed that to `https://yahoo.com/` and added other versions of yahoo as language specific urls:
* `url_de-DE`: `https://de.yahoo.com/`
* `url_en-GB`: `https://uk.yahoo.com/`
* `url_es-ES`: `https://espanol.yahoo.com/`
* `url_fr-FR`: `https://fr.yahoo.com/`