### PR TITLE
Add YouTube, YouTube Music, Gmail / Update Google

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -315,7 +315,7 @@
         "meta": "popular",
         "url": "https://takeout.google.com/",
         "difficulty": "easy",
-        "notes": "Go to https://takeout.google.com/ logged in a Google Account and select the data from every Google Service you need/want and click \"Next Step\". Then you can choose between export now or once every 2 months for 1 year, the file type and size. Click \"Create Export\" and wait until the process is finished. Then, just download your data.",
+        "notes": "Go to [Google Takeout](https://takeout.google.com/) while logged in to a Google Account and select the data from every Google Service you need/want and click \"Next Step\". Then you can choose between export now or once every 2 months for 1 year, the file type and size. Click \"Create Export\" and wait until the process is finished. Then, just download your data.",
         "notes_es-ES": "Ve a https://takeout.google.com/, inicia sesión con tu cuenta de Google, selecciona los servicios que necesites. Puedes elegir entre exportar ahora o exportar cada 2 meses durante un año.",
         "notes_pl-PL": "Wejdź na stronę https://takeout.google.com/, zaloguj się za pomocą swojego konta Google, wybierz potrzebne usługi. Możesz wybrać eksport teraz lub eksport co 2 miesiące przez rok."
     },

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -302,6 +302,13 @@
     },
 
     {
+        "name": "Gmail",
+        "url": "https://takeout.google.com/",
+        "difficulty": "easy",
+        "notes": "Since Gmail is a service by Google, please refer to the instructions for [Google](./#google)."
+    },
+
+    {
         "name": "GOG",
         "url": "https://support.gog.com/hc/en-us/requests/new?form=other&product=gog",
         "difficulty": "hard",

--- a/_data/sites.json
+++ b/_data/sites.json
@@ -850,6 +850,13 @@
     },
 
     {
+        "name": "YouTube / YouTube Music",
+        "url": "https://takeout.google.com/",
+        "difficulty": "easy",
+        "notes": "Since YouTube and YouTube Music are services by Google, please refer to the instructions for [Google](./#google)."
+    },
+
+    {
         "name": "Zanichelli",
         "url": "https://my.zanichelli.it/contattaci",
         "difficulty": "hard",


### PR DESCRIPTION
YouTube, YouTube Music, and Gmail all use the same method to export data that all Google services use. Despite this fact, people searching for a way to export their data from YouTube or Gmail on the website might not necessarily think of searching for Google and therefore won't find a way to export their data. Therefore I added YouTube, YouTube Music, and Gmail with a note referring to Google.

In addition to that, I modified the link in the notes for google to use a clickable markdown link, instead of just plain text.