### PR TITLE
Add QuickSEO

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -737,6 +737,14 @@
     },
 
     {
+        "name": "QuickSEO",
+        "url": "https://quickseo.ai/docs/get-your-data",
+        "difficulty": "hard",
+        "email": "support@quickseo.ai",
+        "notes": "Email support@quickseo.ai to request your account data. They will send it to you by email."
+    },
+
+    {
         "name": "Reddit",
         "meta": "popular",
         "url": "https://www.reddit.com/settings/data-request",


### PR DESCRIPTION
Adds QuickSEO (quickseo.ai) to the catalog.

Users can request their data by emailing support@quickseo.ai as documented at https://quickseo.ai/docs/get-your-data

Difficulty is set to "hard" since there is no self-service data export — users must email support.