### PR TITLE
Add SalahClock

### DIFF
--- a/_data/sites.json
+++ b/_data/sites.json
@@ -791,6 +791,13 @@
     },
 
     {
+        "name": "SalahClock",
+        "url": "https://salahclock.app/dashboard/account",
+        "difficulty": "easy",
+        "notes": "Sign in and open Account from the menu, then click \"Download my data\" to instantly download a JSON file containing all of your account data."
+    },
+
+    {
         "name": "Samsung",
         "url": "https://privacy.samsung.com/mydata/downloads/request",
         "difficulty": "medium",


### PR DESCRIPTION
Adds SalahClock (salahclock.app), a prayer-times display service for mosques and homes.

- **name:** SalahClock
- **url:** https://salahclock.app/dashboard/account
- **difficulty:** easy — a one-click "Download my data" button on the Account page exports a JSON file with the user's full account data (profile, clocks and their settings, public profiles, follows, and billing history).

Placed alphabetically (before Samsung), 4-space indented, and validated with `script/validate_json.rb`.